### PR TITLE
Some improvements to the importing of Sources

### DIFF
--- a/scripts/import_RMG_models.py
+++ b/scripts/import_RMG_models.py
@@ -220,6 +220,22 @@ class SourceImporter(Importer):
             return None, None
         logger.info(f"Reading in source information for {self.name} with DOI:{doi}")
         print(self.name)
+
+        # See if the DOI has already been imported
+        try:
+            dj_source = Source.objects.get(doi=doi)
+        except Source.DoesNotExist:
+            pass
+        else:
+            # if it has, trust it's ok, but update its name
+            dj_source.name = f"{dj_source.name} & {self.name}" # append
+            dj_source.name = " & ".join(set(dj_source.name.split(" & "))) # deduplicate
+            save_model(dj_source, library_name=self.name)
+            setattr(self.dj_km, "source", dj_source)
+            save_model(self.dj_km)
+            self.dj_source = dj_source
+            return dj_source, False
+
         dj_source, source_created = Source.objects.get_or_create(name=self.name)
         print("#" * 50)
         # setting the doi

--- a/scripts/import_RMG_models.py
+++ b/scripts/import_RMG_models.py
@@ -199,9 +199,9 @@ class SourceImporter(Importer):
             matched_doi = None
         elif len(matched_set) > 1:
             logger.warning(
-                f"Found more than one DOI in the souce.txt file for {path}, choosing the first"
+                f"Found more than one DOI in the souce.txt file for {path}, setting to None"
             )
-            matched_doi = matched_list[0]
+            matched_doi = None
         else:
             matched_doi = matched_list[0]
 

--- a/scripts/import_RMG_models.py
+++ b/scripts/import_RMG_models.py
@@ -155,6 +155,12 @@ class SourceImporter(Importer):
     To obtain sources from RMG-models directory
     """
 
+    def __init__(self, *args, **kwargs):
+        super(SourceImporter, self).__init__(*args, **kwargs)
+        self.authors = None
+        self.dj_source = None
+        self.doi = None
+
     def name_from_path(self, path=None):
         """
         Get the library name from the (full) source text file path
@@ -279,6 +285,7 @@ class SourceImporter(Importer):
 
         setattr(self.dj_km, "source", dj_source)
         save_model(self.dj_km)
+        self.dj_source = dj_source
         return dj_source, source_created
 
     def import_authors(self, doi=None):
@@ -319,7 +326,7 @@ class SourceImporter(Importer):
                     order = i + 1
             save_model(dj_author, library_name=self.name)
             authors.append((order, dj_author, author_created))
-
+        self.authors = authors
         return authors
 
     def import_authorship(self):
@@ -331,8 +338,10 @@ class SourceImporter(Importer):
         self.get_doi()
         if not self.doi:
             return False
-        authors = self.import_authors()
-        dj_source, _ = self.import_source()
+        authors = self.authors or self.import_authors()
+        dj_source = self.dj_source
+        if not dj_source:
+            dj_source, _ = self.import_source() # didn't we just do this?
         if not dj_source:
             return False
         logger.info(dj_source)


### PR DESCRIPTION
A few fixes or hopeful improvements to the importer script dealing with the Sources.

- Don't re-import the source and authors needlessly.
- If a publication with that DOI has been imported already, reuse it.
- If a source.txt has more than one DOI, don't assume it's the first.

Details in the individual commit messages