### PR TITLE
Remove duplicate species and names

### DIFF
--- a/database/filters.py
+++ b/database/filters.py
@@ -18,10 +18,10 @@ class SpeciesFilter(django_filters.FilterSet):
         lookup_expr="structure__adjacency_list",
         label="Structure Adjacency List",
     )
-    isomer__structure__electronic_state = django_filters.NumberFilter(
+    isomer__structure__multiplicity = django_filters.NumberFilter(
         field_name="isomer",
-        lookup_expr="structure__electronic_state",
-        label="Structure Electronic State",
+        lookup_expr="structure__multiplicity",
+        label="Structure Multiplicity",
     )
 
     class Meta:

--- a/database/filters.py
+++ b/database/filters.py
@@ -5,7 +5,7 @@ from .models import Species, Reaction, Source
 
 class SpeciesFilter(django_filters.FilterSet):
     speciesname__name = django_filters.CharFilter(
-        field_name="speciesname", lookup_expr="name", label="Species Name"
+        field_name="speciesname", lookup_expr="name", distinct=True, label="Species Name",
     )
     isomer__inchi = django_filters.CharFilter(
         field_name="isomer", lookup_expr="inchi", label="Isomer InChI"
@@ -31,7 +31,7 @@ class SpeciesFilter(django_filters.FilterSet):
 
 class ReactionFilter(django_filters.FilterSet):
     species__name = django_filters.CharFilter(
-        field_name="species", lookup_expr="speciesname__name", label="Species Name"
+        field_name="species", lookup_expr="speciesname__name", distinct=True, label="Species Name"
     )
 
     class Meta:

--- a/database/models/reaction_species.py
+++ b/database/models/reaction_species.py
@@ -44,7 +44,7 @@ class Species(models.Model):
 
     @property
     def names(self):
-        return [name for name in self.speciesname_set.values_list("name", flat=True) if name]
+        return set(name for name in self.speciesname_set.values_list("name", flat=True) if name)
 
     @property
     def structures(self):

--- a/database/templates/database/species_filter.html
+++ b/database/templates/database/species_filter.html
@@ -5,8 +5,8 @@
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>
 <br />
-{% for species in object_list %}
 <div class="list-group">
+    {% for species in object_list %}
     <a
         href="{% url 'species-detail' species.pk %}"
         class="list-group-item list-group-item-action flex-column align-items-start"
@@ -36,8 +36,8 @@
         </ul>
         {% endif %}
     </a>
+    {% endfor %}
 </div>
-{% endfor %}
 <br />
 <nav aria-label="Species Pagination">
     <span class="current">


### PR DESCRIPTION
This change removes duplicate species names from the detail view and removes duplicate species filter results from the list view due to edge-case querying behavior.