### PR TITLE
Fix loss of filter parameters when navigating between pages

### DIFF
--- a/database/templates/database/kineticmodel_detail.html
+++ b/database/templates/database/kineticmodel_detail.html
@@ -56,15 +56,15 @@
         </span>
         <ul class="pagination">
             {% if thermo_transport.has_previous %}
-            <li class="page-item"><a class="page-link" href="?page1=1&page2={{ page2 }}">First</a></li>
-            <li class="page-item"><a class="page-link" href="?page1={{ thermo_transport.previous_page_number }}&page2={{ page2 }}">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page1=1 %}">First</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page1=thermo_transport.previous_page_number%}">Previous</a></li>
             {% else %}
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">First</a></li>
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">Previous</a></li>
             {% endif %}
             {% if thermo_transport.has_next %}
-            <li class="page-item"><a class="page-link" href="?page1={{ thermo_transport.next_page_number }}&page2={{ page2 }}">Next</a></li>
-            <li class="page-item"><a class="page-link" href="?page1={{ thermo_transport.paginator.num_pages }}&page2={{ page2 }}">Last</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page1=thermo_transport.next_page_number%}">Next</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page1=thermo_transport.paginator.num_pages %}">Last</a></li>
             {% else %}
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">Next</a></li>
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">Last</a></li>
@@ -116,15 +116,15 @@
         </span>
         <ul class="pagination">
             {% if kinetics_data.has_previous %}
-            <li class="page-item"><a class="page-link" href="?page1=1&page2={{ page2 }}">First</a></li>
-            <li class="page-item"><a class="page-link" href="?page1={{ kinetics_data.previous_page_number }}&page2={{ page2 }}">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page2=1 %}">First</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page2=kinetics_data.previous_page_number %}">Previous</a></li>
             {% else %}
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">First</a></li>
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">Previous</a></li>
             {% endif %}
             {% if kinetics_data.has_next %}
-            <li class="page-item"><a class="page-link" href="?page1={{ kinetics_data.next_page_number }}&page2={{ page2 }}">Next</a></li>
-            <li class="page-item"><a class="page-link" href="?page1={{ kinetics_data.paginator.num_pages }}&page2={{ page2 }}">Last</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page2=kinetics_data.next_page_number %}">Next</a></li>
+            <li class="page-item"><a class="page-link" href="?{% param_replace page2=kinetics_data.paginator.num_pages %}">Last</a></li>
             {% else %}
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">Next</a></li>
             <li class="page-item disabled"><a class="page-link" tabindex="-1" aria-disabled="true" href="#">Last</a></li>

--- a/database/templates/database/reaction_filter.html
+++ b/database/templates/database/reaction_filter.html
@@ -15,9 +15,9 @@
     </span>
     <ul class="pagination">
         {% if page_obj.has_previous %}
-        <li class="page-item"><a class="page-link" href="?page=1">First</a></li>
+        <li class="page-item"><a class="page-link" href="?{% param_replace page=1 %}">First</a></li>
         <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+            <a class="page-link" href="?{% param_replace page=page_obj.previous_page_number %}">Previous</a>
         </li>
         {% else %}
         <li class="page-item disabled">
@@ -28,10 +28,10 @@
         </li>
         {% endif %} {% if page_obj.has_next %}
         <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+            <a class="page-link" href="?{% param_replace page=page_obj.next_page_number %}">Next</a>
         </li>
         <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+            <a class="page-link" href="?{% param_replace page=page_obj.paginator.num_pages %}">Last</a>
         </li>
         {% else %}
         <li class="page-item disabled">

--- a/database/templates/database/source_filter.html
+++ b/database/templates/database/source_filter.html
@@ -1,6 +1,7 @@
 {% extends "database/base.html" %}
 
 {% load crispy_forms_tags %}
+{% load utils %}
 
 <h1>Species</h1>
 
@@ -11,13 +12,13 @@
     </form>
     <br>
     {% for source in filter.qs %}
-        <a href="{% url "source-detail" source.pk %}">Source</a>: {{ source.name }}<br/>
+        <a href="{% url 'source-detail' source.pk %}">Source</a>: {{ source.name }}<br/>
     {% endfor %}
     <div class="pagination">
         <span class="step-links">
             {% if page_obj.has_previous %}
-                <a href="?page=1">&laquo; first</a>
-                <a href="?page={{ page_obj.previous_page_number }}">previous</a>
+                <a href="?{% param_replace page=1 %}">&laquo; first</a>
+                <a href="?{% param_replace page=page_obj.previous_page_number %}">previous</a>
             {% endif %}
 
             <span class="current">
@@ -25,8 +26,8 @@
             </span>
 
             {% if page_obj.has_next %}
-                <a href="?page={{ page_obj.next_page_number }}">next</a>
-                <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
+                <a href="?{% param_replace page=page_obj.next_page_number %}">next</a>
+                <a href="?{% param_replace page=page_obj.paginator.num_pages %}">last &raquo;</a>
             {% endif %}
         </span>
     </div>

--- a/database/templates/database/species_filter.html
+++ b/database/templates/database/species_filter.html
@@ -1,4 +1,9 @@
-{% extends "database/base.html" %} {% load crispy_forms_tags %} {% block content %}
+{% extends "database/base.html" %}
+
+{% load crispy_forms_tags %}
+{% load utils %}
+
+{% block content %}
 <h1>Species Search</h1>
 <form action="" method="get">
     {{ filter.form|crispy }}
@@ -45,9 +50,9 @@
     </span>
     <ul class="pagination">
         {% if page_obj.has_previous %}
-        <li class="page-item"><a class="page-link" href="?page=1">First</a></li>
+        <li class="page-item"><a class="page-link" href="?{% param_replace page=1%}">First</a></li>
         <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+            <a class="page-link" href="?{% param_replace page=page_obj.previous_page_number%}">Previous</a>
         </li>
         {% else %}
         <li class="page-item disabled">
@@ -58,10 +63,10 @@
         </li>
         {% endif %} {% if page_obj.has_next %}
         <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+            <a class="page-link" href="?{% param_replace page=page_obj.next_page_number%}">Next</a>
         </li>
         <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+            <a class="page-link" href="?{% param_replace page=page_obj.paginator.num_pages%}">Last</a>
         </li>
         {% else %}
         <li class="page-item disabled">

--- a/database/templatetags/utils.py
+++ b/database/templatetags/utils.py
@@ -4,6 +4,37 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 
+@register.simple_tag(takes_context=True)
+def param_replace(context, **kwargs):
+    """
+    Return encoded URL parameters that are the same as the current
+    request's parameters, only with the specified GET parameters added or changed.
+
+    It also removes any empty parameters to keep things neat,
+    so you can remove a parm by setting it to ``""``.
+
+    For example, if you're on the page ``/things/?with_frosting=true&page=5``,
+    then
+
+    <a href="/things/?{% param_replace page=3 %}">Page 3</a>
+
+    would expand to
+
+    <a href="/things/?with_frosting=true&page=3">Page 3</a>
+
+    Based on
+    https://stackoverflow.com/questions/22734695/next-and-before-links-for-a-django-paginated-query/22735278#22735278
+    """
+
+    get = context["request"].GET.copy()
+    for k, v in kwargs.items():
+        get[k] = v
+    for k in [k for k, v in get.items() if not v]:
+        del get[k]
+
+    return get.urlencode()
+
+
 @register.filter
 def fields(obj):
     return [(field.verbose_name, field.value_to_string(obj)) for field in obj._meta.fields]

--- a/database/tests/utils.py
+++ b/database/tests/utils.py
@@ -1,6 +1,53 @@
-import database.models as models
+import database.templatetags.utils as utils
+from django.http import HttpRequest, QueryDict
 from django.template import Template, Context
 from django.test import SimpleTestCase
+
+
+class TestParamReplace(SimpleTestCase):
+    def setUp(self):
+        self.params = {"p1": 1, "p2": 2}
+        request = HttpRequest()
+        get = QueryDict(mutable=True)
+        get.update(**self.params)
+        request.GET = get
+        self.context = Context({"request": request})
+
+    def render_params(self, **params):
+        get = QueryDict(mutable=True)
+        get.update(**params)
+
+        return get.urlencode()
+
+    def _test(self, expected_params, **param_changes):
+        expected = self.render_params(**expected_params)
+        actual = utils.param_replace(self.context, **param_changes)
+
+        self.assertEqual(expected, actual)
+
+    def test_single_replacement(self):
+        self._test({"p1": 1, "p2": 3}, p2=3)
+
+    def test_multiple_replacements(self):
+        self._test({"p1": 2, "p2": 1}, p1=2, p2=1)
+
+    def test_add_param(self):
+        self._test({"p1": 1, "p2": 2, "p3": 3}, p3=3)
+
+    def test_remove_param(self):
+        self._test({"p2": 2}, p1="")
+
+    def test_add_and_replace(self):
+        self._test({"p1": 2, "p2": 2, "p3": 3}, p1=2, p3=3)
+
+    def test_add_and_remove(self):
+        self._test({"p2": 2, "p3": 3}, p1="", p3=3)
+
+    def test_replace_and_remove(self):
+        self._test({"p2": 3}, p1="", p2=3)
+
+    def test_add_replace_and_remove(self):
+        self._test({"p2": 3, "p3": 3}, p1="", p2=3, p3=3)
 
 
 class TestPluralize(SimpleTestCase):


### PR DESCRIPTION
This change prevents the loss of filtered search results when navigating across the paginated results.