### PR TITLE
Add reaction search by reactant and product

### DIFF
--- a/database/filters.py
+++ b/database/filters.py
@@ -66,6 +66,7 @@ class ReactionFilter(django_filters.FilterSet):
         reaction_ids = Stoichiometry.objects.filter(
             **{name: value}, stoichiometry__lt=0
         ).values_list("reaction", flat=True)
+
         return Reaction.objects.filter(id__in=reaction_ids)
 
     def filter_product(self, queryset, name, value):
@@ -77,7 +78,10 @@ class ReactionFilter(django_filters.FilterSet):
 
     class Meta:
         model = Reaction
-        fields = ("prime_id", "reversible",)
+        fields = (
+            "prime_id",
+            "reversible",
+        )
 
 
 class SourceFilter(django_filters.FilterSet):

--- a/database/filters.py
+++ b/database/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 from django.db.models import Count
 
-from .models import Species, Reaction, Source, Stoichiometry
+from .models import Species, Reaction, Source
 
 
 class SpeciesFilter(django_filters.FilterSet):
@@ -63,18 +63,10 @@ class ReactionFilter(django_filters.FilterSet):
     )
 
     def filter_reactant(self, queryset, name, value):
-        reaction_ids = Stoichiometry.objects.filter(
-            **{name: value}, stoichiometry__lt=0
-        ).values_list("reaction", flat=True)
-
-        return Reaction.objects.filter(id__in=reaction_ids)
+        return queryset.filter(**{name: value}, stoichiometry__stoichiometry__lt=0)
 
     def filter_product(self, queryset, name, value):
-        reaction_ids = Stoichiometry.objects.filter(
-            **{name: value}, stoichiometry__gt=0
-        ).values_list("reaction", flat=True)
-
-        return Reaction.objects.filter(id__in=reaction_ids)
+        return queryset.filter(**{name: value}, stoichiometry__stoichiometry__gt=0)
 
     class Meta:
         model = Reaction

--- a/database/filters.py
+++ b/database/filters.py
@@ -29,9 +29,6 @@ class SpeciesFilter(django_filters.FilterSet):
 
 
 class ReactionFilter(django_filters.FilterSet):
-    # species__name = django_filters.CharFilter(
-    #     field_name="species", lookup_expr="speciesname__name", distinct=True, label="Species Name"
-    # )
     reactant1 = django_filters.ModelChoiceFilter(
         queryset=Species.objects.annotate(reaction_count=Count("reaction")).filter(
             reaction_count__gt=0
@@ -80,7 +77,7 @@ class ReactionFilter(django_filters.FilterSet):
 
     class Meta:
         model = Reaction
-        fields = ("reversible",)
+        fields = ("prime_id", "reversible",)
 
 
 class SourceFilter(django_filters.FilterSet):

--- a/database/templates/database/reaction_filter.html
+++ b/database/templates/database/reaction_filter.html
@@ -9,6 +9,41 @@
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>
 <br />
+<nav aria-label="Reaction Pagination">
+    <span class="current">
+        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+    </span>
+    <ul class="pagination">
+        {% if page_obj.has_previous %}
+        <li class="page-item"><a class="page-link" href="?page=1">First</a></li>
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <a class="page-link" tabindex="-1" aria-disabled="true" href="#">First</a>
+        </li>
+        <li class="page-item disabled">
+            <a class="page-link" tabindex="-1" aria-disabled="true" href="#">Previous</a>
+        </li>
+        {% endif %} {% if page_obj.has_next %}
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+        </li>
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <a class="page-link" tabindex="-1" aria-disabled="true" href="#">Next</a>
+        </li>
+        <li class="page-item disabled">
+            <a class="page-link" tabindex="-1" aria-disabled="true" href="#">Last</a>
+        </li>
+        {% endif %}
+    </ul>
+</nav>
+<br />
 {% for reaction in object_list %}
 <div class="list-group">
     <a


### PR DESCRIPTION
This change adds the ability to search for a reaction by specifying up to 2 reactants and/or  up to 2 products. The selection is done by choosing from a dropdown list of species that have a related reaction. This probably will not work with species that are on both sides of a reaction currently.