### PR TITLE
Fail reaction imports when there are no reactants or no products

### DIFF
--- a/database/scripts/import_rmg_models.py
+++ b/database/scripts/import_rmg_models.py
@@ -165,14 +165,18 @@ def create_and_save_species(kinetic_model, name, rmg_molecule, inchi="", **model
         logging.exception("Failed to import species")
 
 
-def get_reaction_from_stoich_set(stoichiometry_data, **models):
-    filter_candidates = []
-    for stoich, species in stoichiometry_data:
-        filter_candidates = models["Reaction"].filter(
+def get_or_create_reaction_from_stoich_data(stoich_data, models, **defaults):
+    stoich_data_iter = iter(stoich_data)
+    stoich, species = next(stoich_data_iter)
+    queryset = models["Reaction"].objects.filter(
+        stoichiometry__stoichiometry=stoich, stoichiometry__species=species
+    )
+    for stoich, species in stoich_data_iter:
+        queryset = queryset.filter(
             stoichiometry__stoichiometry=stoich, stoichiometry__species=species
         )
 
-    return filter_candidates.get()
+    return queryset.get_or_create(defaults=defaults)
 
 
 def create_and_save_reaction(kinetic_model, rmg_reaction, **models):

--- a/database/tests/test_import_rmg_models.py
+++ b/database/tests/test_import_rmg_models.py
@@ -1,30 +1,63 @@
 from django.core.exceptions import MultipleObjectsReturned
 from django.test import TestCase
 from database import models
-from database.migrations.import_rmg_models import *
+from database.scripts.import_rmg_models import *
 
 
 class TestImportRmgModels(TestCase):
-    def get_reaction_from_stoich_set(self):
+    def test_get_or_create_reaction_from_stoich_set(self):
+        """
+        A Reaction with a unique set of stoich-species pairs should be found if the entire set of pairs is queried.
+
+        A partial match should return a Reaction if the partial match is unique.
+        A duplicate reaction or a non-unique partial match should throw MultipleObjectsReturned.
+        """
+
         species_a = models.Species.objects.create(formula="A")
         species_b = models.Species.objects.create(formula="B")
         species_c = models.Species.objects.create(formula="C")
         reaction1 = models.Reaction.objects.create(reversible=False)
         reaction2 = models.Reaction.objects.create(reversible=False)
         reaction3 = models.Reaction.objects.create(reversible=True)
-        stoich_a1 = models.Stoichiometry.create(reaction=reaction1, species=species_a, stoichiometry=-1)
-        stoich_b1 = models.Stoichiometry.create(reaction=reaction1, species=species_b, stoichiometry=1)
-        stoich_a2 = models.Stoichiometry.create(reaction=reaction2, species=species_a, stoichiometry=-1)
-        stoich_b2 = models.Stoichiometry.create(reaction=reaction2, species=species_b, stoichiometry=1)
-        stoich_c2 = models.Stoichiometry.create(reaction=reaction2, species=species_c, stoichiometry=1)
-        stoich_a3 = models.Stoichiometry.create(reaction=reaction3, species=species_a, stoichiometry=-1)
-        stoich_b3 = models.Stoichiometry.create(reaction=reaction3, species=species_b, stoichiometry=1)
+        reaction1.species.add(species_a, through_defaults={"stoichiometry": -1})
+        reaction1.species.add(species_b, through_defaults={"stoichiometry": 1})
+        reaction1.save()
+        reaction2.species.add(species_a, through_defaults={"stoichiometry": -1})
+        reaction2.species.add(species_b, through_defaults={"stoichiometry": 1})
+        reaction2.species.add(species_c, through_defaults={"stoichiometry": 1})
+        reaction2.save()
+        reaction3.species.add(species_a, through_defaults={"stoichiometry": -1})
+        reaction3.species.add(species_b, through_defaults={"stoichiometry": 1})
+        reaction3.save()
 
-        stoich_data_2 = [(-1, species_a), (1, species_b), (1, species_c)]
-        stoich_data_1 = [(-1, species_a), (1, species_b)]
-        stoich_data_missing = [(-1, species_a), (1, species_c)]
+        stoich_data_exact_match = [(-1, species_a), (1, species_b), (1, species_c)]
+        stoich_data_exact_match_multiple = [(-1, species_a), (1, species_b)]
+        stoich_data_partial_match = [(-1, species_a), (1, species_c)]
+        stoich_data_partial_match_multiple = [(-1, species_a)]
         _models = {"Reaction": models.Reaction}
 
-        self.assertEqual(reaction1, get_reaction_from_stoich_set(stoich_data_2, **_models))
-        self.assertRaises(MultipleObjectsReturned, get_reaction_from_stoich_set(stoich_data_1, **_models))
-        self.assertRaises(models.Reaction.DoesNotExist, get_reaction_from_stoich_set(stoich_data_missing, **_models))
+        exact_match_reaction, exact_match_created = get_or_create_reaction_from_stoich_data(
+            stoich_data_exact_match, _models, reversible=True
+        )
+        partial_match_reaction, partial_match_created = get_or_create_reaction_from_stoich_data(
+            stoich_data_partial_match, _models, reversible=True
+        )
+
+        self.assertFalse(exact_match_created)
+        self.assertEqual(reaction2, exact_match_reaction)
+        self.assertFalse(partial_match_created)
+        self.assertEqual(reaction2, partial_match_reaction)
+        self.assertRaises(
+            MultipleObjectsReturned,
+            get_or_create_reaction_from_stoich_data,
+            stoich_data_exact_match_multiple,
+            _models,
+            reversible=True,
+        )
+        self.assertRaises(
+            MultipleObjectsReturned,
+            get_or_create_reaction_from_stoich_data,
+            stoich_data_partial_match_multiple,
+            _models,
+            reversible=True,
+        )


### PR DESCRIPTION
I noticed in previous runs of the importer script that some reactions ended up with no reactants or no products. This change adds a check for that and fails the import of the reaction if that is the case. Additionally, the flow of the reaction import has been changed to search for the reaction given stoichiometry data first, then creates the reaction if it is not found. When the reaction is being created, all of the stoichiometric data is added before saving to prevent reaction uniqueness validation issues that arise when the stoichiometries are partially saved and conflict with another existing reaction.