### PR TITLE
Improve Docker Build Process

### DIFF
--- a/.github/workflows/kms-build.yml
+++ b/.github/workflows/kms-build.yml
@@ -1,0 +1,17 @@
+name: KMS Build
+on:
+  push:
+    branches: [ master ]
+jobs:
+  kms_build:
+    name: KMS Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        run: |
+          echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker build -f Dockerfile.build -t ghcr.io/comocheng/kineticmodelssite/kms-build:latest
+      - name: push
+        run: |
+          docker push ghcr.io/comocheng/kineticmodelssite/kms-build:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,5 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Tests
         run: |
+          echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker pull ghcr.io/comocheng/kineticmodelssite/kms-build:latest
           docker volume create rmg-models
           docker-compose run web ./bin/test.sh --rm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM comocheng/kms-build
+FROM ghcr.io/comocheng/kineticmodelssite/kms-build:latest
 
 RUN conda config --set channel_priority strict
 RUN conda env update --prefix $ENV_PREFIX --file environment.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,8 @@
-FROM continuumio/miniconda3:latest
+FROM comocheng/kms-build
 
-ENV PYTHONUNBUFFERED=1
-
-WORKDIR /app
-SHELL ["/bin/bash", "-c"]
-
-RUN apt-get update && apt-get -y install \
-    gcc \
-    g++ \
-    libxrender-dev \
-    libsm6 \
-    libxext6
-
-COPY environment.yml /app/
-RUN mkdir /kms_env
-ENV ENV_PREFIX=/kms_env
-RUN conda env create --prefix $ENV_PREFIX --file environment.yml --force
+RUN conda config --set channel_priority strict
+RUN conda env update --prefix $ENV_PREFIX --file environment.yml
+RUN conda clean -afy
 ENV PATH /kms_env/bin:$PATH
 ENV CONDA_DEFAULT_ENV /kms_env
 RUN source activate /kms_env

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,19 @@
+FROM continuumio/miniconda3:latest
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get -y install \
+    gcc \
+    g++ \
+    libxrender-dev \
+    libsm6 \
+    libxext6
+
+RUN mkdir /kms_env
+ENV ENV_PREFIX=/kms_env
+COPY environment.yml /app/
+RUN conda env create --prefix $ENV_PREFIX --file environment.yml --force
+RUN echo "rmg==3.0" > /kms_env/conda-meta/pinned

--- a/environment.yml
+++ b/environment.yml
@@ -1,24 +1,17 @@
-name: kms_env
+name: kms
 channels:
-  - defaults
-  - pr-omethe-us
-  - rmg
-  - rdkit
-  - cantera
-  - pytorch
-  - anaconda
   - conda-forge
+  - rmg
+  - nodefaults
 dependencies:
   - python>=3.7
-  - beautifulsoup4
+  - nomkl
   - cairo
   - cairocffi
-  - matplotlib>=1.5
   - xlrd
   - xlwt
   - habanero>=0.6,<0.7
   - rmg==3.0
-  - pandas
   - django==3.0
   - django-filter
   - django-extensions


### PR DESCRIPTION
This change attempts to speed up docker build times by hosting installation and build steps in a different image, which is then used by the main image. The build stage is hosted on [Docker Hub](https://hub.docker.com/repository/docker/comocheng/kms-build)